### PR TITLE
Use absolute file URL for cached video

### DIFF
--- a/ios/VideoCache.m
+++ b/ios/VideoCache.m
@@ -14,7 +14,17 @@ RCT_EXPORT_BLOCKING_SYNCHRONOUS_METHOD(convert:(NSString *)url)
         return url;
       }
     }
-    return [KTVHTTPCache proxyURLWithOriginalURL:[NSURL URLWithString:url]].absoluteString;
+    NSURL* videoUrl = [NSURL URLWithString:url];
+    @try {
+        NSURL *completedCacheFileURL = [KTVHTTPCache cacheCompleteFileURLWithURL:videoUrl];
+        if (completedCacheFileURL != nil) {
+            return completedCacheFileURL.absoluteString;
+        }
+    }
+    @catch (NSException *exception) {
+    }
+    
+    return [KTVHTTPCache proxyURLWithOriginalURL:videoUrl].absoluteString;
 }
 
 RCT_EXPORT_METHOD(convertAsync:(NSString *)url
@@ -29,7 +39,17 @@ RCT_EXPORT_METHOD(convertAsync:(NSString *)url
       return;
     }
   }
-  resolve([KTVHTTPCache proxyURLWithOriginalURL:[NSURL URLWithString:url]].absoluteString);
+  NSURL* videoUrl = [NSURL URLWithString:url];
+  @try {
+      NSURL *completedCacheFileURL = [KTVHTTPCache cacheCompleteFileURLWithURL:videoUrl];
+      if (completedCacheFileURL != nil) {
+          resolve(completedCacheFileURL.absoluteString);
+          return;
+      }
+  }
+  @catch (NSException *exception) {
+  }
+  resolve([KTVHTTPCache proxyURLWithOriginalURL:videoUrl].absoluteString);
 }
 
 @end


### PR DESCRIPTION
We can use the local url of the video file for the cached video, and this will be faster than proxy url while play video.