### PR TITLE
fix: android classifier error

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -115,7 +115,7 @@ afterEvaluate { project ->
     }
 
     task androidJavadocJar(type: Jar, dependsOn: androidJavadoc) {
-        classifier = 'javadoc'
+        archiveClassifier = 'javadoc'
         from androidJavadoc.destinationDir
     }
 


### PR DESCRIPTION
Regarding to this issue https://github.com/zhigang1992/react-native-video-cache/issues/72 
This commit will fix error on Gradle 8.0