### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,14 @@ Edit your `android/build.gradle` file and add the following lines:
 ```
 
 to your `allprojects/repositories`
+
+### Running android in release mode
+
+To run in release mode you will need to make sure you add `android:usesCleartextTraffic="true"` to your main android manifest like so:
+
+```xml
+    <application
+      ...
+      android:usesCleartextTraffic="true"
+      ...>
+```


### PR DESCRIPTION
The default android manifest for react native does not include android:usesCleartextTraffic="true" so its worth mentioning that it needs to be added for the module to actually work properly in production other wise you will get this error https://github.com/danikula/AndroidVideoCache/issues/134